### PR TITLE
Update to pom-scijava parent, and switch to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+jdk: oraclejdk8
+branches:
+  only: master
+install: true
+script: ".travis/build.sh"
+after_success: ".travis/notify.sh Travis-Success"
+after_failure: ".travis/notify.sh Travis-Failure"
+env:
+  global:
+  - secure: SiEbNAAJgRWklDAefPzGjedosKutPXapAKcjLnOyBV1i6GTgJIwiRjEvInCPc4UC6AxXdkU+Iv3rM5M9e91zwF+C9gp9Ko/W9iM8OXPGLB9GAfjEOWlQ1oLHDQAIP0ExXPWuVscnt20vQEsyytbN6VPdEkH/2/T3Y9u0Ba9FY78=
+  - secure: m9wqISaFrC7sUkmwzQAjYj/KdQzTF9oKWpHxav3JZp7JGa5TxC9BEQoTABSCY//NFkO2OYhi5AgkWAKyItTwnyWDrW/rtzoaSe6UIvhAYquC60jlUg+Lzu7Q3VVmNJbDGsVo6lo5DHbba3eJqb/VqKCetVH6Zc5TBwwHY5fovOU=

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+dir="$(dirname "$0")"
+test "$TRAVIS_SECURE_ENV_VARS" = true \
+  -a "$TRAVIS_PULL_REQUEST" = false \
+  -a "$TRAVIS_BRANCH" = master &&
+  mvn -Pdeploy-to-imagej deploy --settings "$dir/settings.xml" ||
+  mvn install

--- a/.travis/notify.sh
+++ b/.travis/notify.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+curl -fs "https://jenkins.imagej.net/job/$1/buildWithParameters?token=$TOKEN_NAME&repo=$TRAVIS_REPO_SLUG&commit=$TRAVIS_COMMIT&pr=$TRAVIS_PULL_REQUEST"

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,0 +1,14 @@
+<settings>
+  <servers>
+    <server>
+      <id>imagej.releases</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+    <server>
+      <id>imagej.snapshots</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+  </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,49 @@
 	<artifactId>trakem2_tps</artifactId>
 	<version>1.1.3-SNAPSHOT</version>
 
+	<developers>
+		<developer>
+			<id>bogovicj</id>
+			<name>John Bogovic</name>
+			<url>http://imagej.net/User:Bogovic</url>
+			<roles>
+				<role>founder</role>
+				<role>lead</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+		<developer>
+			<id>axtimwalde</id>
+			<name>Stephan Saalfeld</name>
+			<url>http://imagej.net/User:Saalfeld</url>
+			<roles>
+				<role>founder</role>
+				<role>lead</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+	</developers>
+	<contributors>
+		<contributor>
+			<name>Curtis Rueden</name>
+			<url>http://imagej.net/User:Rueden</url>
+			<properties><id>ctrueden</id></properties>
+		</contributor>
+		<contributor>
+			<name>Mark Hiner</name>
+			<url>http://imagej.net/User:Hinerm</url>
+			<properties><id>hinerm</id></properties>
+		</contributor>
+	</contributors>
+
 	<repositories>
 		<repository>
 			<id>imagej.public</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -8,9 +9,15 @@
 		<version>2.0.0</version>
 	</parent>
 
-
 	<artifactId>trakem2_tps</artifactId>
 	<version>1.1.3-SNAPSHOT</version>
+
+	<repositories>
+		<repository>
+			<id>imagej.public</id>
+			<url>http://maven.imagej.net/content/groups/public</url>
+		</repository>
+	</repositories>
 
 	<dependencies>
 		<dependency>
@@ -39,10 +46,4 @@
 			<version>1.8</version>
 		</dependency>
 	</dependencies>
-	<repositories>
-		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
-		</repository>
-	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,30 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>sc.fiji</groupId>
-		<artifactId>pom-trakem2</artifactId>
-		<version>2.0.0</version>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>14.0.0</version>
 	</parent>
 
+	<groupId>sc.fiji</groupId>
 	<artifactId>trakem2_tps</artifactId>
 	<version>1.1.3-SNAPSHOT</version>
+
+	<name>TrakEM2 thin plate splines</name>
+	<description>Thin plate splines in TrakEM2.</description>
+	<url>https://github.com/saalfeldlab/trakem2-tps</url>
+	<inceptionYear>2014</inceptionYear>
+	<organization>
+		<name>Fiji</name>
+		<url>https://fiji.sc/</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>GNU General Public License v2+</name>
+			<url>https://www.gnu.org/licenses/gpl.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
 	<developers>
 		<developer>
@@ -54,6 +71,33 @@
 			<properties><id>hinerm</id></properties>
 		</contributor>
 	</contributors>
+
+	<mailingLists>
+		<mailingList>
+			<name>ImageJ Forum</name>
+			<archive>http://forum.imagej.net/</archive>
+		</mailingList>
+	</mailingLists>
+
+	<scm>
+		<url>https://github.com/saalfeldlab/trakem2-tps</url>
+		<connection>scm:git:git://github.com/saalfeldlab/trakem2-tps</connection>
+		<developerConnection>scm:git:git@github.com:saalfeldlab/trakem2-tps</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
+	<issueManagement>
+		<system>GitHub</system>
+		<url>https://github.com/saalfeldlab/trakem2-tps/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Travis CI</system>
+		<url>https://travis-ci.org/saalfeldlab/trakem2-tps</url>
+	</ciManagement>
+
+	<properties>
+		<license.licenseName>gpl_v2</license.licenseName>
+		<license.copyrightOwners>Howard Hughes Medical Institute.</license.copyrightOwners>
+	</properties>
 
 	<repositories>
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
 		</dependency>
 	</dependencies>
 	<repositories>
-		<!-- NB: for project parent -->
 		<repository>
 			<id>imagej.public</id>
 			<url>http://maven.imagej.net/content/groups/public</url>


### PR DESCRIPTION
This also adds `<developers>` and `<contributors>`.

Note that to fully switch to Travis, you will need to visit https://travis-ci.org/saalfeldlab/trakem2-tps and enable the repository there.